### PR TITLE
set PATH for vpn-{up,down}.sh markedly

### DIFF
--- a/chnroutes.py
+++ b/chnroutes.py
@@ -14,6 +14,7 @@ def generate_ovpn(metric):
     upscript_header = """\
 #!/bin/bash -
 
+export PATH="/bin:/sbin:/usr/sbin:/usr/bin"
 OLDGW=$(ip route show 0/0 | head -n1 | grep 'via' | grep -Po '\d+\.\d+\.\d+\.\d+')
 
 ip -batch - <<EOF
@@ -21,6 +22,7 @@ ip -batch - <<EOF
     downscript_header = """\
 #!/bin/bash -
 
+export PATH="/bin:/sbin:/usr/sbin:/usr/bin"
 ip -batch - <<EOF
 """
 


### PR DESCRIPTION
set PATH for vpn-{up,down}.sh because of lacking PATH environment
when executing vpn-{up.down}.sh scripts in some system, which
causes failing to startup openvpn and make it exit.

Details:
    Openvpn uses 'execve' function to run externel command, but
    'execve' does not look at PATH. If calling command without
    setting PATH correctly, it will unable to find the command(s)
    and make openvpn exit. In this case, when openvpn calling
    'vpn-up.sh', it will prompt 'ip command not found' and openvpn
    fails to startup. I met this problem in my Slackware 13.37 box,
    but Ubuntu 10.04.4 LTS works well. It seems that Ubuntu's bash
    sets PATH correctly, but Slackware's only read ~/.bashrc and
    PATH turns to bash's default setting which is
    '/usr/gnu/bin:/usr/local/bin:/bin:/usr/bin:.'.

```
Acknowledge: http://goo.gl/DrUf9 & http://goo.gl/sDbAe
```
