### PR TITLE
ovpn: bug fix for $OLDGW with multiple routers

### DIFF
--- a/chnroutes.py
+++ b/chnroutes.py
@@ -15,7 +15,7 @@ def generate_ovpn(_):
 #!/bin/bash -
 
 export PATH="/bin:/sbin:/usr/sbin:/usr/bin"
-OLDGW=$(ip route show 0/0 | sed -e 's/^default//')
+OLDGW=$(ip route show 0/0 | grep -v metric | sed -e 's/^default//')
 
 ip -batch - <<EOF
 """

--- a/chnroutes.py
+++ b/chnroutes.py
@@ -15,7 +15,7 @@ def generate_ovpn(_):
 #!/bin/bash -
 
 export PATH="/bin:/sbin:/usr/sbin:/usr/bin"
-OLDGW=$(ip route show 0/0 | grep -v metric | sed -e 's/^default//')
+OLDGW=$(ip route show 0/0 | head -n1 | sed -e 's/^default//')
 
 ip -batch - <<EOF
 """


### PR DESCRIPTION
Currently, vpn-up.sh failed when multiple routers is available. e.g. when both wired and wireless network is available.The problem is caused by $OLDGW will contain two lines begin with `via`.In the difference of commit 37d256f6c3bce85d50caa7883c50a9c3e7916de6, there is an extra  `| head -n1` handling this problem but it has been removed.
